### PR TITLE
Forcing callbacks to return an error object

### DIFF
--- a/pkg/module/rabbitmq/workflow.go
+++ b/pkg/module/rabbitmq/workflow.go
@@ -7,7 +7,7 @@ import (
 	"log"
 )
 
-type Callback func()
+type Callback func() error
 
 func OnMessageReceive(ch *amqp.Channel, queueName string, callback Callback) chan bool {
 

--- a/pkg/module/rabbitmq/workflow.go
+++ b/pkg/module/rabbitmq/workflow.go
@@ -31,7 +31,8 @@ func OnMessageReceive(ch *amqp.Channel, queueName string, callback Callback) cha
 
 			// Executing the module's callback function
 			log.Printf("Executing callback function...")
-			callback()
+			err := callback()
+			util.FailOnError(err, "Callback failed")
 
 			// Sending a response
 			log.Printf("...callback function completed. Sending response...")


### PR DESCRIPTION
Synclib will take care of callbacks' error handling